### PR TITLE
speed up HLL estimates by avoiding divisions

### DIFF
--- a/examples/estimate.rs
+++ b/examples/estimate.rs
@@ -4,7 +4,7 @@ use card_est_array::{
 };
 
 const N: usize = 1_000_000;
-const ITERS: usize = 50_000_000;
+const ITERS: usize = 100_000_000;
 
 fn main() {
     let logic = HyperLogLogBuilder::new(N)

--- a/examples/estimate.rs
+++ b/examples/estimate.rs
@@ -1,0 +1,23 @@
+use card_est_array::{impls::{HyperLogLogBuilder, SliceEstimatorArray}, traits::{Estimator, EstimatorArrayMut, EstimatorMut}};
+
+const N: usize = 1_000_000;
+const ITERS: usize = 50_000_000;
+
+fn main() {
+    let logic = HyperLogLogBuilder::new(N)
+        .log_2_num_reg(6)
+        .build::<usize>().unwrap();
+
+    let mut array = SliceEstimatorArray::new(logic.clone(), 1);
+    for i in 0..N {
+        let mut estimator = array.get_estimator_mut(0);
+        estimator.add(i);
+    }
+
+    let start = std::time::Instant::now();
+    for _ in 0..ITERS {
+        let _ = std::hint::black_box(array.get_estimator_mut(0).estimate());
+    }
+    let elapsed = start.elapsed();
+    println!("{} ns/estimation", elapsed.as_nanos() as f64 / ITERS as f64);
+}

--- a/examples/estimate.rs
+++ b/examples/estimate.rs
@@ -1,4 +1,7 @@
-use card_est_array::{impls::{HyperLogLogBuilder, SliceEstimatorArray}, traits::{Estimator, EstimatorArrayMut, EstimatorMut}};
+use card_est_array::{
+    impls::{HyperLogLogBuilder, SliceEstimatorArray},
+    traits::{Estimator, EstimatorArrayMut, EstimatorMut},
+};
 
 const N: usize = 1_000_000;
 const ITERS: usize = 50_000_000;
@@ -6,7 +9,8 @@ const ITERS: usize = 50_000_000;
 fn main() {
     let logic = HyperLogLogBuilder::new(N)
         .log_2_num_reg(6)
-        .build::<usize>().unwrap();
+        .build::<usize>()
+        .unwrap();
 
     let mut array = SliceEstimatorArray::new(logic.clone(), 1);
     for i in 0..N {

--- a/src/impls/hyper_log_log.rs
+++ b/src/impls/hyper_log_log.rs
@@ -22,23 +22,29 @@ use super::DefaultEstimator;
 type HashResult = u64;
 
 /// Compute 2^{-exp} exploiting IEEE754 format.
-/// 
+///
 /// IEEE 754 32-bit float format has the MSB as sign,
 /// then 8 exponent bits, and finally 23 faction (mantissa) bits.
 /// The represented value is (-1)^{sign} (1 + fraction) 2^{exp - 127}.
 /// So by summing 127 to the exponent and shifting it we directly build
 /// the wanted value without any division.
-/// 
-/// But as a downside it works only up to exp = 126 while 
+///
+/// But as a downside it works only up to exp = 126 while
 /// floats allow to store up to exp = 126 + 23 but that requires
 /// setting exponent to 0 and storing the value in the mantissa.
 #[inline(always)]
 #[allow(dead_code)]
 pub(crate) unsafe fn negative_power_of_two_f32(exp: u32) -> f32 {
-    debug_assert!(exp < 127); 
+    debug_assert!(exp < 127);
     let v = (127 - exp) << 23;
     let res = f32::from_ne_bytes(v.to_ne_bytes());
-    debug_assert_eq!(res, 2.0_f32.powi(-(exp as i32)), "for exponent: {} value: {:032b}", exp, v);
+    debug_assert_eq!(
+        res,
+        2.0_f32.powi(-(exp as i32)),
+        "for exponent: {} value: {:032b}",
+        exp,
+        v
+    );
     res
 }
 
@@ -50,7 +56,13 @@ pub(crate) unsafe fn negative_power_of_two_f64(exp: u64) -> f64 {
     debug_assert!(exp < 1023);
     let v = (1023 - exp) << 52;
     let res = f64::from_ne_bytes(v.to_ne_bytes());
-    debug_assert_eq!(res, 2.0_f64.powi(-(exp as i32)), "for exponent: {} value: {:064b}", exp, v);
+    debug_assert_eq!(
+        res,
+        2.0_f64.powi(-(exp as i32)),
+        "for exponent: {} value: {:064b}",
+        exp,
+        v
+    );
     res
 }
 
@@ -62,7 +74,7 @@ mod test_negative_power_of_two {
     fn test_f32() {
         for exp in 0..127 {
             assert_eq!(
-                unsafe{negative_power_of_two_f32(exp)},
+                unsafe { negative_power_of_two_f32(exp) },
                 2.0_f32.powi(-(exp as i32)),
             )
         }
@@ -72,7 +84,7 @@ mod test_negative_power_of_two {
     fn test_f64() {
         for exp in 0..1023 {
             assert_eq!(
-                unsafe{negative_power_of_two_f64(exp)},
+                unsafe { negative_power_of_two_f64(exp) },
                 2.0_f64.powi(-(exp as i32)),
             )
         }
@@ -238,7 +250,7 @@ impl<
             if value == 0 {
                 zeroes += 1;
             }
-            harmonic_mean += unsafe{negative_power_of_two_f64(value)};
+            harmonic_mean += unsafe { negative_power_of_two_f64(value) };
         }
 
         let mut estimate = self.alpha_m_m / harmonic_mean;

--- a/src/impls/hyper_log_log.rs
+++ b/src/impls/hyper_log_log.rs
@@ -21,76 +21,6 @@ use super::DefaultEstimator;
 /// The type returned by the hash function.
 type HashResult = u64;
 
-/// Compute 2^{-exp} exploiting IEEE754 format.
-///
-/// IEEE 754 32-bit float format has the MSB as sign,
-/// then 8 exponent bits, and finally 23 faction (mantissa) bits.
-/// The represented value is (-1)^{sign} (1 + fraction) 2^{exp - 127}.
-/// So by summing 127 to the exponent and shifting it we directly build
-/// the wanted value without any division.
-///
-/// But as a downside it works only up to exp = 126 while
-/// floats allow to store up to exp = 126 + 23 but that requires
-/// setting exponent to 0 and storing the value in the mantissa.
-#[inline(always)]
-#[allow(dead_code)]
-pub(crate) unsafe fn negative_power_of_two_f32(exp: u32) -> f32 {
-    debug_assert!(exp < 127);
-    let v = (127 - exp) << 23;
-    let res = f32::from_ne_bytes(v.to_ne_bytes());
-    debug_assert_eq!(
-        res,
-        2.0_f32.powi(-(exp as i32)),
-        "for exponent: {} value: {:032b}",
-        exp,
-        v
-    );
-    res
-}
-
-#[inline(always)]
-/// Like [`negative_power_of_two_f32`] but for f64.
-/// f64 has also 1 bit sign, 11 bits for exponent and 52 bits for mantissa.
-/// So it works up to exp=1023.
-pub(crate) unsafe fn negative_power_of_two_f64(exp: u64) -> f64 {
-    debug_assert!(exp < 1023);
-    let v = (1023 - exp) << 52;
-    let res = f64::from_ne_bytes(v.to_ne_bytes());
-    debug_assert_eq!(
-        res,
-        2.0_f64.powi(-(exp as i32)),
-        "for exponent: {} value: {:064b}",
-        exp,
-        v
-    );
-    res
-}
-
-#[cfg(test)]
-mod test_negative_power_of_two {
-    use super::*;
-
-    #[test]
-    fn test_f32() {
-        for exp in 0..127 {
-            assert_eq!(
-                unsafe { negative_power_of_two_f32(exp) },
-                2.0_f32.powi(-(exp as i32)),
-            )
-        }
-    }
-
-    #[test]
-    fn test_f64() {
-        for exp in 0..1023 {
-            assert_eq!(
-                unsafe { negative_power_of_two_f64(exp) },
-                2.0_f64.powi(-(exp as i32)),
-            )
-        }
-    }
-}
-
 /// Estimator logic implementing the HyperLogLog algorithm.
 ///
 /// Instances are built using [`HyperLogLogBuilder`], which provides convenient
@@ -250,7 +180,7 @@ impl<
             if value == 0 {
                 zeroes += 1;
             }
-            harmonic_mean += unsafe { negative_power_of_two_f64(value) };
+            harmonic_mean += 1.0 / (1_u64 << value) as f64;
         }
 
         let mut estimate = self.alpha_m_m / harmonic_mean;


### PR DESCRIPTION
Minor improvement of HyperLogLog estimation. Instead of computing `1.0 / (1 << value)`, we can directly build the correct IEEE754 float representation to avoid the division.

In the primitive benchmark I added, it goes from 58ns per `estimate` to 48ns on average.